### PR TITLE
fix: update file encoding for read and write operations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from os.path import basename, splitext
 
 from setuptools import setup, find_packages
 
-with open("README.rst") as readme_file:
+with open("README.rst", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 
@@ -15,7 +15,7 @@ def get_version(*file_paths):
     Extract the version string from the file at the given relative path fragments.
     """
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
-    version_file = open(filename).read()
+    version_file = open(filename, encoding="utf-8").read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)

--- a/src/cc2olx/main.py
+++ b/src/cc2olx/main.py
@@ -23,10 +23,10 @@ def convert_one_file(input_file, workspace, link_file=None, passport_file=None):
     olx_filename = cartridge.directory.parent / (cartridge.directory.name + "-course.xml")
     policy_filename = cartridge.directory.parent / "policy.json"
 
-    with open(str(olx_filename), "w") as olxfile:
+    with open(str(olx_filename), "w", encoding="utf-8") as olxfile:
         olxfile.write(olx_export.xml())
 
-    with open(str(policy_filename), "w") as policy:
+    with open(str(policy_filename), "w", encoding="utf-8") as policy:
         policy.write(olx_export.policy())
 
     tgz_filename = (workspace / cartridge.directory.name).with_suffix(".tar.gz")

--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -429,12 +429,6 @@ class Cartridge:
         self.version = self.metadata.get("schema", {}).get("version", self.version)
         return data
 
-    def write_xml(self, text, output_base, output_file):
-        text += "\n"
-        output_path = os.path.join(output_base, output_file)
-        with open(output_path, "w") as output:
-            output.write(text)
-
     def get_course_xml(self):
         text = '<course org="{org}" course="{number}" url_name="{run}" />'.format(
             org=self.get_course_org(),

--- a/src/cc2olx/tools/video_download.py
+++ b/src/cc2olx/tools/video_download.py
@@ -107,7 +107,7 @@ def find_video_urls(input_html):
 
 def write_csv(outfile, urls, relpaths):
     fieldnames = ["Relative File Path", "External Video Link", "Youtube Id"]
-    with open(outfile, "w", newline="") as csvfile:
+    with open(outfile, "w", newline="", encoding="utf-8") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def iframe_content(fixtures_data_dir):
     """
 
     html_file_path = str(fixtures_data_dir / "imscc_file" / "iframe.html")
-    with open(html_file_path, "r") as htmlcontent:
+    with open(html_file_path, "r", encoding="utf-8") as htmlcontent:
         content = htmlcontent.read()
     return content
 


### PR DESCRIPTION
## [MST-1419](https://openedx.atlassian.net/browse/MST-1419)

All read and write operations for text files should be properly encoded using `utf-8` to avoid errors when running the tool on a PC. 