### PR TITLE
remove now unnecessary zipp constraint

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -24,7 +24,7 @@ idna==3.3
     # via requests
 packaging==21.3
     # via tox
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,6 +7,3 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
-
-# Version 2 requires Python 3.5
-zipp==1.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,8 +19,6 @@ certifi==2021.10.8
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via
     #   -r requirements/ci.txt
@@ -42,8 +40,6 @@ coverage[toml]==6.3.2
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-cryptography==36.0.2
-    # via secretstorage
 distlib==0.3.4
     # via
     #   -r requirements/ci.txt
@@ -70,10 +66,6 @@ iniconfig==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 keyring==23.5.0
     # via twine
 lxml==4.8.0
@@ -104,7 +96,7 @@ pip-tools==6.6.0
     # via -r requirements/pip-tools.txt
 pkginfo==1.8.2
     # via twine
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -126,8 +118,6 @@ pycodestyle==2.8.0
     # via
     #   -r requirements/quality.txt
     #   flake8
-pycparser==2.21
-    # via cffi
 pyflakes==2.4.0
     # via
     #   -r requirements/quality.txt
@@ -150,7 +140,7 @@ pytest-cov==3.0.0
     # via -r requirements/quality.txt
 pytest-mock==3.7.0
     # via -r requirements/quality.txt
-readme-renderer==34.0
+readme-renderer==35.0
     # via twine
 requests==2.27.1
     # via
@@ -165,8 +155,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.2.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -189,7 +177,7 @@ tox==3.25.0
     # via -r requirements/ci.txt
 twine==4.0.0
     # via -r requirements/dev.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/quality.txt
     #   black

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -203,10 +203,8 @@ xmlformatter==0.2.4
     # via -r requirements/quality.txt
 youtube-dl==2021.12.17
     # via -r requirements/quality.txt
-zipp==1.2.0
-    # via
-    #   -c requirements/constraints.txt
-    #   importlib-metadata
+zipp==3.8.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -46,7 +46,7 @@ packaging==21.3
     #   pytest
 pathspec==0.9.0
     # via black
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via black
 pluggy==1.0.0
     # via
@@ -81,7 +81,7 @@ tomli==2.0.1
     #   black
     #   coverage
     #   pytest
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via black
 urllib3==1.26.9
     # via


### PR DESCRIPTION
zipp constraint was put in when we were on an old version of python, we can let it be free now which brings it to version 3.8.0 which is the general zipp version across edx.