### PR TITLE
feat: replace reserved characters in imscc filenames

### DIFF
--- a/src/cc2olx/filesystem.py
+++ b/src/cc2olx/filesystem.py
@@ -5,6 +5,8 @@ import zipfile
 from xml.etree import ElementTree
 from lxml import etree
 
+from cc2olx.utils import clean_file_name
+
 logger = logging.getLogger()
 
 
@@ -43,8 +45,12 @@ def unzip_directory(path_src, path_dst_base=None):
 
     path_dst = path_dst_base / path_src.stem
 
-    with zipfile.ZipFile(str(path_src)) as output_file:
-        output_file.extractall(str(path_dst))
+    output_file = zipfile.ZipFile(str(path_src))
+    zip_list = output_file.infolist()
+
+    for zip in zip_list:
+        zip.filename = clean_file_name(zip.filename)
+        output_file.extract(zip, path=str(path_dst))
 
     return path_dst
 

--- a/src/cc2olx/utils.py
+++ b/src/cc2olx/utils.py
@@ -2,6 +2,7 @@
 import logging
 import string
 import csv
+import re
 
 logger = logging.getLogger()
 
@@ -89,3 +90,20 @@ def passport_file_parser(filename: str):
             passports[row["consumer_id"]] = passport
 
         return passports
+
+
+def clean_file_name(filename: str):
+    """
+    Replaces any reserved characters with an underscore so the filename can be used in read and write
+    operations
+
+    Args:
+        filename (str) - path of the file to be cleaned
+
+    Returns:
+        filename (str) - filename with the reserved characters removed
+    """
+    special_characters = r"[\?\*\|:><]"
+
+    cleaned_name = re.sub(special_characters, "_", filename)
+    return cleaned_name

--- a/tests/fixtures_data/imscc_file/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_file/imsmanifest.xml
@@ -167,5 +167,8 @@
         <resource identifier="resource_external_tool_retrieve" type="webcontent" href="wiki_content/external_tool_retrieve">
             <file href="wiki_content/external_tool_retrieve.html"/>
         </resource>
+        <resource identifier="resource_module-|-introduction" type="webcontent" href="wiki_content/module-|-introduction.html">
+            <file href="wiki_content/module-|-introduction.html"/>
+        </resource>
     </resources>
 </manifest>

--- a/tests/fixtures_data/imscc_file/wiki_content/module-_-introduction.html
+++ b/tests/fixtures_data/imscc_file/wiki_content/module-_-introduction.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>Vertical</title>
+<meta name="identifier" content="resource_module-|-introduction"/>
+<meta name="editing_roles" content="teachers"/>
+<meta name="workflow_state" content="active"/>
+</head>
+<body>
+<p>Lorem ipsum...</p>
+<a href="%24WIKI_REFERENCE%24/pages/wiki_content">Wiki Content</a>
+</body>
+</html>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,7 +37,7 @@ def test_load_manifest_extracted(imscc_file, settings, temp_workspace_dir):
         "version": cartridge_version,
     }
 
-    assert len(cartridge.resources) == 17
+    assert len(cartridge.resources) == 18
     assert len(cartridge.resources[0]["children"]) == 6
     assert isinstance(cartridge.resources[0]["children"][0], ResourceFile)
 
@@ -365,6 +365,20 @@ def test_cartridge_get_resource_content(cartridge):
             '<meta name="workflow_state" content="active"/>\n'
             "</head>\n<body>\n"
             '<p>Lorem ipsum...</p>\n<a href="%24CANVAS_OBJECT_REFERENCE%24/quizzes/abc">Canvas Content</a>'
+            "\n</body>\n</html>\n"
+        },
+    )
+
+    assert cartridge.get_resource_content("resource_module-|-introduction") == (
+        "html",
+        {
+            "html": '<html>\n<head>\n<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>\n'
+            "<title>Vertical</title>\n"
+            '<meta name="identifier" content="resource_module-|-introduction"/>\n'
+            '<meta name="editing_roles" content="teachers"/>\n'
+            '<meta name="workflow_state" content="active"/>\n'
+            "</head>\n<body>\n"
+            '<p>Lorem ipsum...</p>\n<a href="%24WIKI_REFERENCE%24/pages/wiki_content">Wiki Content</a>'
             "\n</body>\n</html>\n"
         },
     )


### PR DESCRIPTION
Some courses in IMSCC format contain references to files with reserved characters in the filename. This causes the cc2olx tool to fail on operating systems for which those reserved characters are defined. 

We should rename those files and update references to them in our version of the IMS manifest tree. We do not need to modify the manifest file directly, as it is only used once to produce the tree structure. 