### PR TITLE
fix: upgrade pip-tools to fix bug in version 6.6.0

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.1.2
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION
This commit upgrades the version of pip-tools used in this repository from 6.6.0 to 6.6.2.

In version 6.6.0 of pip-tools, there is a bug that is preventing pip-tools from working. This is breaking the Python requirements update GitHub action in this repository.

The error is ImportError: cannot import name 'BAR_TYPES' from 'pip._internal.cli.progress_bars'. The error was reported in https://github.com/jazzband/pip-tools/issues/1617. The fix to this bug was released in version 6.6.2 of pip-tools. See the comment https://github.com/jazzband/pip-tools/issues/1617#issuecomment-1126245586.