### PR TITLE
fix: actually use url_name set on assessments

### DIFF
--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -164,7 +164,7 @@ class OlxExport:
             for child in children:
                 if "title" in element_data:
                     child.setAttribute("display_name", element_data["title"])
-                    if element_data["identifierref"]:
+                    if element_data["identifierref"] and not child.getAttribute("url_name"):
                         child.setAttribute("url_name", element_data["identifierref"])
 
                 element.appendChild(child)

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -72,7 +72,7 @@
 					</stringresponse>
 				</problem>
 				<html display_name="QTI" url_name="resource_4_qti"><![CDATA[Sample Answer]]></html>
-				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="resource_4_qti">
+				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="essay_question_id4">
 					<title>Open Response Assessment</title>
 					<assessments>
 						<assessment name="staff-assessment" required="True"/>
@@ -102,7 +102,7 @@
 						<feedback_default_text>Feedback prompt default text</feedback_default_text>
 					</rubric>
 				</openassessment>
-				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="resource_4_qti">
+				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="essay_question_2_id5">
 					<title>Open Response Assessment</title>
 					<assessments>
 						<assessment name="staff-assessment" required="True"/>


### PR DESCRIPTION
We put in code specifically to make sure assessments each had their own url_name, but unfortunately that field is wiped out before it can actually take effect.

Fixes 15d4c023ce858ad7a5ed78718f382b7225b2a451 - notably the original code should have caused a test change but did not have one.

Tested by uploading a cc2olx converted from master and one converted with this code to stage. The master has the problem reported in https://2u-internal.atlassian.net/browse/CR-5011 - the Canvas Survey at the end of the course cannot be deleted. The updated import does not have the problem.