### PR TITLE
fix: if discussion content is missing text, add missing content text

### DIFF
--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -433,7 +433,8 @@ class OlxExport:
         node.setAttribute("discussion_category", details["title"])
         node.setAttribute("discussion_target", details["title"])
         html_node = self.doc.createElement("html")
-        txt = self.doc.createCDATASection(details["text"])
+        txt = "MISSING CONTENT" if details["text"] is None else details["text"]
+        txt = self.doc.createCDATASection(txt)
         html_node.appendChild(txt)
         return [html_node, node]
 


### PR DESCRIPTION
## [MST-2006](https://2u-internal.atlassian.net/browse/MST-2006)

A canvas course with missing content in the discussion text section was causing the CC2OLX tool to break mid-conversion. Instead of erroring out, the tool should instead convert the content, and add a "MISSING CONTENT" message to the discussion node, as is done for other types of content that can't convert.

I have tested this change locally and can confirm that the tool now converts the course successfully.