### PR TITLE
fix: add ci requirements to ensure that dependency conflicts are avoided

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -14,7 +14,7 @@ lxml==4.9.3
     # via -r requirements/base.in
 requests==2.31.0
     # via -r requirements/base.in
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
 youtube-dl==2021.12.17
     # via -r requirements/base.in

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,6 @@
 # Requirements for running tests in CI
 -c constraints.txt
+-r quality.txt            # Core and quality check dependencies
 
 coverage
 tox

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,37 +4,107 @@
 #
 #    make upgrade
 #
-cachetools==5.3.2
-    # via tox
-chardet==5.2.0
-    # via tox
-colorama==0.4.6
-    # via tox
-coverage==7.3.2
-    # via -r requirements/ci.in
+appdirs==1.4.4
+    # via virtualenv
+black==23.11.0
+    # via -r requirements/quality.txt
+certifi==2023.11.17
+    # via
+    #   -r requirements/quality.txt
+    #   requests
+charset-normalizer==3.3.2
+    # via
+    #   -r requirements/quality.txt
+    #   requests
+click==8.1.7
+    # via
+    #   -r requirements/quality.txt
+    #   black
+coverage[toml]==7.3.2
+    # via
+    #   -r requirements/ci.in
+    #   -r requirements/quality.txt
+    #   coverage
+    #   pytest-cov
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
     # via
     #   tox
     #   virtualenv
+flake8==6.1.0
+    # via -r requirements/quality.txt
+idna==3.4
+    # via
+    #   -r requirements/quality.txt
+    #   requests
+iniconfig==2.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   pytest
+lxml==4.9.3
+    # via -r requirements/quality.txt
+mccabe==0.7.0
+    # via
+    #   -r requirements/quality.txt
+    #   flake8
+mypy-extensions==1.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   black
 packaging==23.2
     # via
-    #   pyproject-api
+    #   -r requirements/quality.txt
+    #   black
+    #   pytest
     #   tox
-platformdirs==3.11.0
+pathspec==0.11.2
+    # via
+    #   -r requirements/quality.txt
+    #   black
+platformdirs==4.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   black
+pluggy==1.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   pytest
+    #   tox
+py==1.11.0
+    # via tox
+pycodestyle==2.11.1
+    # via
+    #   -r requirements/quality.txt
+    #   flake8
+pyflakes==3.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   flake8
+pytest==7.4.3
+    # via
+    #   -r requirements/quality.txt
+    #   pytest-cov
+    #   pytest-mock
+pytest-cov==4.1.0
+    # via -r requirements/quality.txt
+pytest-mock==3.12.0
+    # via -r requirements/quality.txt
+requests==2.31.0
+    # via -r requirements/quality.txt
+six==1.16.0
     # via
     #   tox
     #   virtualenv
-pluggy==1.3.0
-    # via tox
-pyproject-api==1.6.1
-    # via tox
-tomli==2.0.1
-    # via
-    #   pyproject-api
-    #   tox
-tox==4.11.3
+tox==3.28.0
     # via -r requirements/ci.in
-virtualenv==20.24.6
+urllib3==2.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   requests
+virtualenv==20.4.7
     # via tox
+xmlformatter==0.2.4
+    # via -r requirements/quality.txt
+youtube-dl==2021.12.17
+    # via -r requirements/quality.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,97 +4,85 @@
 #
 #    make upgrade
 #
-black==23.10.1
-    # via -r requirements/quality.txt
+appdirs==1.4.4
+    # via
+    #   -r requirements/ci.txt
+    #   virtualenv
+black==23.11.0
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
 build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
 bump2version==1.0.1
     # via -r requirements/dev.in
-cachetools==5.3.2
+certifi==2023.11.17
     # via
     #   -r requirements/ci.txt
-    #   tox
-certifi==2023.7.22
-    # via
     #   -r requirements/quality.txt
     #   requests
-cffi==1.16.0
-    # via cryptography
-chardet==5.2.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox
 charset-normalizer==3.3.2
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 click==8.1.7
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   black
     #   pip-tools
-colorama==0.4.6
-    # via
-    #   -r requirements/ci.txt
-    #   tox
 coverage[toml]==7.3.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
-    # via secretstorage
 distlib==0.3.7
     # via
     #   -r requirements/ci.txt
     #   virtualenv
 docutils==0.20.1
     # via readme-renderer
-exceptiongroup==1.1.3
-    # via
-    #   -r requirements/quality.txt
-    #   pytest
 filelock==3.13.1
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
 flake8==6.1.0
-    # via -r requirements/quality.txt
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
 idna==3.4
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 importlib-metadata==6.8.0
     # via
-    #   -r requirements/pip-tools.txt
-    #   build
     #   keyring
     #   twine
-importlib-resources==6.1.1
-    # via keyring
 iniconfig==2.0.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pytest
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
-keyring==24.2.0
+keyring==24.3.0
     # via twine
 lxml==4.9.3
-    # via -r requirements/quality.txt
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
 markdown-it-py==3.0.0
     # via rich
 mccabe==0.7.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   flake8
 mdurl==0.1.2
@@ -103,6 +91,7 @@ more-itertools==10.1.0
     # via jaraco-classes
 mypy-extensions==1.0.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   black
 nh3==0.2.14
@@ -114,65 +103,69 @@ packaging==23.2
     #   -r requirements/quality.txt
     #   black
     #   build
-    #   pyproject-api
     #   pytest
     #   tox
 pathspec==0.11.2
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   black
 pip-tools==7.3.0
     # via -r requirements/pip-tools.txt
 pkginfo==1.9.6
     # via twine
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   black
-    #   tox
-    #   virtualenv
 pluggy==1.3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.11.1
-    # via
-    #   -r requirements/quality.txt
-    #   flake8
-pycparser==2.21
-    # via cffi
-pyflakes==3.1.0
-    # via
-    #   -r requirements/quality.txt
-    #   flake8
-pygments==2.16.1
-    # via
-    #   readme-renderer
-    #   rich
-pyproject-api==1.6.1
+py==1.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
+pycodestyle==2.11.1
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   flake8
+pyflakes==3.1.0
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   flake8
+pygments==2.17.1
+    # via
+    #   readme-renderer
+    #   rich
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
 pytest==7.4.3
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pytest-cov
     #   pytest-mock
 pytest-cov==4.1.0
-    # via -r requirements/quality.txt
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
 pytest-mock==3.12.0
-    # via -r requirements/quality.txt
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
 readme-renderer==42.0
     # via twine
 requests==2.31.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests-toolbelt
     #   twine
@@ -180,38 +173,24 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.6.0
+rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
-tomli==2.0.1
+six==1.16.0
     # via
     #   -r requirements/ci.txt
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
-    #   black
-    #   build
-    #   coverage
-    #   pip-tools
-    #   pyproject-api
-    #   pyproject-hooks
-    #   pytest
     #   tox
-tox==4.11.3
+    #   virtualenv
+tox==3.28.0
     # via -r requirements/ci.txt
 twine==4.0.2
     # via -r requirements/dev.in
-typing-extensions==4.8.0
+urllib3==2.1.0
     # via
-    #   -r requirements/quality.txt
-    #   black
-    #   rich
-urllib3==2.0.7
-    # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
     #   twine
-virtualenv==20.24.6
+virtualenv==20.4.7
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -221,14 +200,15 @@ wheel==0.41.3
     #   -r requirements/pip-tools.txt
     #   pip-tools
 xmlformatter==0.2.4
-    # via -r requirements/quality.txt
-youtube-dl==2021.12.17
-    # via -r requirements/quality.txt
-zipp==3.17.0
     # via
-    #   -r requirements/pip-tools.txt
-    #   importlib-metadata
-    #   importlib-resources
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+youtube-dl==2021.12.17
+    # via
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,23 +8,14 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.8.0
-    # via build
 packaging==23.2
     # via build
 pip-tools==7.3.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
-tomli==2.0.1
-    # via
-    #   build
-    #   pip-tools
-    #   pyproject-hooks
 wheel==0.41.3
     # via pip-tools
-zipp==3.17.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.41.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3.1
     # via -r requirements/pip.in
-setuptools==68.2.2
+setuptools==69.0.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-black==23.10.1
+black==23.11.0
     # via -r requirements/quality.in
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   requests
@@ -21,10 +21,6 @@ coverage[toml]==7.3.2
     #   -r requirements/test.txt
     #   coverage
     #   pytest-cov
-exceptiongroup==1.1.3
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 flake8==6.1.0
     # via -r requirements/quality.in
 idna==3.4
@@ -48,7 +44,7 @@ packaging==23.2
     #   pytest
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 pluggy==1.3.0
     # via
@@ -69,15 +65,7 @@ pytest-mock==3.12.0
     # via -r requirements/test.txt
 requests==2.31.0
     # via -r requirements/test.txt
-tomli==2.0.1
-    # via
-    #   -r requirements/test.txt
-    #   black
-    #   coverage
-    #   pytest
-typing-extensions==4.8.0
-    # via black
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -r requirements/test.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/base.txt
     #   requests
@@ -16,8 +16,6 @@ coverage[toml]==7.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
-exceptiongroup==1.1.3
-    # via pytest
 idna==3.4
     # via
     #   -r requirements/base.txt
@@ -41,11 +39,7 @@ pytest-mock==3.12.0
     # via -r requirements/test.in
 requests==2.31.0
     # via -r requirements/base.txt
-tomli==2.0.1
-    # via
-    #   coverage
-    #   pytest
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   -r requirements/base.txt
     #   requests


### PR DESCRIPTION
Both requirements defined in ci.txt and quality.txt make use of `platformdirs`. Because both ci.txt and quality.txt are requirements in dev.txt, ci.txt and quality.txt must share the same versions of dependencies. 

My solution was to explicitly make quality.txt a requirement of ci.txt, which ensures that they share the same version of `platformdirs`.