### PR TITLE
fix: CDATA nesting into CDATA is avoided as it is prohibited

### DIFF
--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -363,7 +363,8 @@ class OlxExport:
         html = self._process_static_links(details["html"])
         if self.link_file:
             html, video_olx = self._process_html_for_iframe(html)
-        txt = self.doc.createCDATASection(html)
+        node_creation_method = self.doc.createTextNode if "]]>" in html else self.doc.createCDATASection
+        txt = node_creation_method(html)
         child.appendChild(txt)
         nodes.append(child)
         for olx in video_olx:
@@ -434,7 +435,8 @@ class OlxExport:
         node.setAttribute("discussion_target", details["title"])
         html_node = self.doc.createElement("html")
         txt = "MISSING CONTENT" if details["text"] is None else details["text"]
-        txt = self.doc.createCDATASection(txt)
+        node_creation_method = self.doc.createTextNode if "]]>" in txt else self.doc.createCDATASection
+        txt = node_creation_method(txt)
         html_node.appendChild(txt)
         return [html_node, node]
 


### PR DESCRIPTION
During some OLX nodes creation (HTML, discussions) the entire content is wrapped into `CDATA` tag. But such content can already contain `CDATA` tags inside it, which causes errors. So, when it occurs, it is made that the content is added into the text node instead of the `CDATA` one.