### PR TITLE
feat: Source specifying for relative links is allowed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,12 @@ The link map file can be supplied using `-f` or `--link_file`::
 
     cc2olx -r zip -i <IMSCC_FILE> -f <CSV_FILE>
 
+If the original course content contains relative links and the resources
+(images, documents etc) the links point to are not included into the exported
+course dump, you can specify their source using `-s` flag:
+
+    cc2olx -i <IMSCC_FILE> -s <RELATIVE_LINKS_SOURCE>
+
 Dockerization
 -------------
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 usefixtures = chdir_to_workspace
+DJANGO_SETTINGS_MODULE = cc2olx.django_settings

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,6 @@
 # Core requirements for this package
 
+Django
 lxml
 requests
 youtube-dl

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,17 +4,27 @@
 #
 #    make upgrade
 #
-certifi==2024.2.2
+asgiref==3.8.1
+    # via django
+backports-zoneinfo==0.2.1
+    # via django
+certifi==2024.12.14
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-idna==3.6
-    # via requests
-lxml==5.1.0
+django==4.2.17
     # via -r requirements/base.in
-requests==2.31.0
+idna==3.10
+    # via requests
+lxml==5.3.0
     # via -r requirements/base.in
-urllib3==2.2.1
+requests==2.32.3
+    # via -r requirements/base.in
+sqlparse==0.5.3
+    # via django
+typing-extensions==4.12.2
+    # via asgiref
+urllib3==2.2.3
     # via requests
 youtube-dl==2021.12.17
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -105,8 +105,11 @@ pytest==8.3.4
     # via
     #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest-cov
+    #   pytest-django
     #   pytest-mock
 pytest-cov==5.0.0
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
+pytest-django==4.9.0
     # via -r /home/misha/work/cc2olx/requirements/quality.txt
 pytest-mock==3.14.0
     # via -r /home/misha/work/cc2olx/requirements/quality.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,125 +4,141 @@
 #
 #    make upgrade
 #
-black==24.3.0
-    # via -r requirements/quality.txt
-cachetools==5.3.3
-    # via tox
-certifi==2024.2.2
+asgiref==3.8.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+    #   django
+backports-zoneinfo==0.2.1
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+    #   django
+black==24.8.0
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
+cachetools==5.5.0
+    # via tox
+certifi==2024.12.14
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests
 chardet==5.2.0
     # via tox
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
 colorama==0.4.6
     # via tox
-coverage[toml]==7.4.4
+coverage[toml]==7.6.1
     # via
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   -r requirements/ci.in
-    #   -r requirements/quality.txt
     #   pytest-cov
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
-exceptiongroup==1.2.0
+django==4.2.17
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
+exceptiongroup==1.2.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest
-filelock==3.13.3
+filelock==3.16.1
     # via
     #   tox
     #   virtualenv
-flake8==7.0.0
-    # via -r requirements/quality.txt
-idna==3.6
+flake8==7.1.1
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
+idna==3.10
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests
 iniconfig==2.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest
-lxml==5.1.0
-    # via -r requirements/quality.txt
+lxml==5.3.0
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
 mccabe==0.7.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   flake8
 mypy-extensions==1.0.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
-packaging==24.0
+packaging==24.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
     #   pyproject-api
     #   pytest
     #   tox
 pathspec==0.12.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
-platformdirs==4.2.0
+platformdirs==4.3.6
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.11.1
+pycodestyle==2.12.1
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   flake8
 pyflakes==3.2.0
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   flake8
-pyproject-api==1.6.1
+pyproject-api==1.8.0
     # via tox
-pytest==8.1.1
+pytest==8.3.4
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest-cov
     #   pytest-mock
 pytest-cov==5.0.0
-    # via -r requirements/quality.txt
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
 pytest-mock==3.14.0
-    # via -r requirements/quality.txt
-requests==2.31.0
-    # via -r requirements/quality.txt
-tomli==2.0.1
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
+requests==2.32.3
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
+sqlparse==0.5.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+    #   django
+tomli==2.2.1
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
     #   coverage
     #   pyproject-api
     #   pytest
     #   tox
-tox==4.14.2
+tox==4.23.2
     # via -r requirements/ci.in
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+    #   asgiref
     #   black
-urllib3==2.2.1
+    #   tox
+urllib3==2.2.3
     # via
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests
-virtualenv==20.25.1
+virtualenv==20.28.1
     # via tox
-xmlformatter==0.2.6
-    # via -r requirements/quality.txt
+xmlformatter==0.2.8
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt
 youtube-dl==2021.12.17
-    # via -r requirements/quality.txt
+    # via -r /home/misha/work/cc2olx/requirements/quality.txt

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -11,22 +11,21 @@
 # Note: Changes to this file will automatically be used by other repos, referencing
 #  this file from Github directly. It does not require packaging in edx-lint.
 
-
 # using LTS django version
 Django<5.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+# See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
 
-# opentelemetry requires version 6.x at the moment:
-# https://github.com/open-telemetry/opentelemetry-python/issues/3570
-# Normally this could be added as a constraint in edx-django-utils, where we're
-# adding the opentelemetry dependency. However, when we compile pip-tools.txt,
-# that uses version 7.x, and then there's no undoing that when compiling base.txt.
-# So we need to pin it globally, for now.
-# Ticket for unpinning: https://github.com/openedx/edx-lint/issues/407
-importlib-metadata<7
+# Cause: https://github.com/openedx/edx-lint/issues/458
+# This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
+pip<24.3
+
+# Cause: https://github.com/openedx/edx-lint/issues/475
+# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
+urllib3<2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -205,8 +205,13 @@ pytest==8.3.4
     #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest-cov
+    #   pytest-django
     #   pytest-mock
 pytest-cov==5.0.0
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+pytest-django==4.9.0
     # via
     #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   -r /home/misha/work/cc2olx/requirements/quality.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,264 +4,287 @@
 #
 #    make upgrade
 #
-black==24.3.0
+asgiref==3.8.1
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
-build==1.1.1
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+    #   django
+backports-tarfile==1.2.0
+    # via jaraco-context
+backports-zoneinfo==0.2.1
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+    #   django
+black==24.8.0
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+build==1.2.2.post1
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/pip-tools.txt
     #   pip-tools
 bump2version==1.0.1
     # via -r requirements/dev.in
-cachetools==5.3.3
+cachetools==5.5.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   tox
-certifi==2024.2.2
+certifi==2024.12.14
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
 chardet==5.2.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   tox
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/pip-tools.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
     #   pip-tools
 colorama==0.4.6
     # via
-    #   -r requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   tox
-coverage[toml]==7.4.4
+coverage[toml]==7.6.1
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest-cov
-cryptography==42.0.5
+cryptography==44.0.0
     # via secretstorage
-distlib==0.3.8
+distlib==0.3.9
     # via
-    #   -r requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   virtualenv
+django==4.2.17
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
 docutils==0.20.1
     # via readme-renderer
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest
-filelock==3.13.3
+filelock==3.16.1
     # via
-    #   -r requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   tox
     #   virtualenv
-flake8==7.0.0
+flake8==7.1.1
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
-idna==3.6
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+idna==3.10
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /home/misha/work/cc2olx/requirements/pip-tools.txt
     #   build
     #   keyring
     #   twine
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via keyring
 iniconfig==2.0.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest
-jaraco-classes==3.3.1
+jaraco-classes==3.4.0
     # via keyring
-jaraco-context==4.3.0
+jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.0.0
+jaraco-functools==4.1.0
     # via keyring
 jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-keyring==25.0.0
+keyring==25.5.0
     # via twine
-lxml==5.1.0
+lxml==5.3.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
 markdown-it-py==3.0.0
     # via rich
 mccabe==0.7.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   flake8
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.2.0
+more-itertools==10.5.0
     # via
     #   jaraco-classes
     #   jaraco-functools
 mypy-extensions==1.0.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
-nh3==0.2.17
+nh3==0.2.20
     # via readme-renderer
-packaging==24.0
+packaging==24.2
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/pip-tools.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
     #   build
     #   pyproject-api
     #   pytest
     #   tox
+    #   twine
 pathspec==0.12.1
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
 pip-tools==7.4.1
-    # via -r requirements/pip-tools.txt
-pkginfo==1.10.0
+    # via -r /home/misha/work/cc2olx/requirements/pip-tools.txt
+pkginfo==1.12.0
     # via twine
-platformdirs==4.2.0
+platformdirs==4.3.6
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.11.1
+pycodestyle==2.12.1
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   flake8
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pyflakes==3.2.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   flake8
-pygments==2.17.2
+pygments==2.19.1
     # via
     #   readme-renderer
     #   rich
-pyproject-api==1.6.1
+pyproject-api==1.8.0
     # via
-    #   -r requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   tox
-pyproject-hooks==1.0.0
+pyproject-hooks==1.2.0
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /home/misha/work/cc2olx/requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.1.1
+pytest==8.3.4
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   pytest-cov
     #   pytest-mock
 pytest-cov==5.0.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
 pytest-mock==3.14.0
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
 readme-renderer==43.0
     # via twine
-requests==2.31.0
+requests==2.32.3
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.7.1
+rich==13.9.4
     # via twine
 secretstorage==3.3.3
     # via keyring
-tomli==2.0.1
+sqlparse==0.5.3
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+    #   django
+tomli==2.2.1
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/pip-tools.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   black
     #   build
     #   coverage
     #   pip-tools
     #   pyproject-api
-    #   pyproject-hooks
     #   pytest
     #   tox
-tox==4.14.2
-    # via -r requirements/ci.txt
-twine==5.0.0
+tox==4.23.2
+    # via -r /home/misha/work/cc2olx/requirements/ci.txt
+twine==6.0.1
     # via -r requirements/dev.in
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+    #   asgiref
     #   black
     #   rich
-urllib3==2.2.1
+    #   tox
+urllib3==2.2.3
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
     #   requests
     #   twine
-virtualenv==20.25.1
+virtualenv==20.28.1
     # via
-    #   -r requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
     #   tox
-wheel==0.43.0
+wheel==0.45.1
     # via
+    #   -r /home/misha/work/cc2olx/requirements/pip-tools.txt
     #   -r requirements/dev.in
-    #   -r requirements/pip-tools.txt
     #   pip-tools
-xmlformatter==0.2.6
+xmlformatter==0.2.8
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
 youtube-dl==2021.12.17
     # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
-zipp==3.18.1
+    #   -r /home/misha/work/cc2olx/requirements/ci.txt
+    #   -r /home/misha/work/cc2olx/requirements/quality.txt
+zipp==3.20.2
     # via
-    #   -r requirements/pip-tools.txt
+    #   -r /home/misha/work/cc2olx/requirements/pip-tools.txt
     #   importlib-metadata
     #   importlib-resources
 

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,28 +4,27 @@
 #
 #    make upgrade
 #
-build==1.1.1
+build==1.2.2.post1
     # via pip-tools
-click==8.1.7
+click==8.1.8
     # via pip-tools
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via build
-packaging==24.0
+packaging==24.2
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
-pyproject-hooks==1.0.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   build
     #   pip-tools
-    #   pyproject-hooks
-wheel==0.43.0
+wheel==0.45.1
     # via pip-tools
-zipp==3.18.1
+zipp==3.20.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.43.0
+wheel==0.45.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.0
+pip==24.3.1
     # via -r requirements/pip.in
-setuptools==69.2.0
+setuptools==75.3.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,83 +4,100 @@
 #
 #    make upgrade
 #
-black==24.3.0
+asgiref==3.8.1
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
+    #   django
+backports-zoneinfo==0.2.1
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
+    #   django
+black==24.8.0
     # via -r requirements/quality.in
-certifi==2024.2.2
+certifi==2024.12.14
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via black
-coverage[toml]==7.4.4
+coverage[toml]==7.6.1
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   pytest-cov
-exceptiongroup==1.2.0
+django==4.2.17
+    # via -r /home/misha/work/cc2olx/requirements/test.txt
+exceptiongroup==1.2.2
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   pytest
-flake8==7.0.0
+flake8==7.1.1
     # via -r requirements/quality.in
-idna==3.6
+idna==3.10
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   requests
 iniconfig==2.0.0
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   pytest
-lxml==5.1.0
-    # via -r requirements/test.txt
+lxml==5.3.0
+    # via -r /home/misha/work/cc2olx/requirements/test.txt
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==24.0
+packaging==24.2
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   black
     #   pytest
 pathspec==0.12.1
     # via black
-platformdirs==4.2.0
+platformdirs==4.3.6
     # via black
-pluggy==1.4.0
+pluggy==1.5.0
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   pytest
-pycodestyle==2.11.1
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pytest==8.1.1
+pytest==8.3.4
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   pytest-cov
     #   pytest-mock
 pytest-cov==5.0.0
-    # via -r requirements/test.txt
+    # via -r /home/misha/work/cc2olx/requirements/test.txt
 pytest-mock==3.14.0
-    # via -r requirements/test.txt
-requests==2.31.0
-    # via -r requirements/test.txt
-tomli==2.0.1
+    # via -r /home/misha/work/cc2olx/requirements/test.txt
+requests==2.32.3
+    # via -r /home/misha/work/cc2olx/requirements/test.txt
+sqlparse==0.5.3
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
+    #   django
+tomli==2.2.1
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   black
     #   coverage
     #   pytest
-typing-extensions==4.10.0
-    # via black
-urllib3==2.2.1
+typing-extensions==4.12.2
     # via
-    #   -r requirements/test.txt
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
+    #   asgiref
+    #   black
+urllib3==2.2.3
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   requests
-xmlformatter==0.2.6
-    # via -r requirements/test.txt
+xmlformatter==0.2.8
+    # via -r /home/misha/work/cc2olx/requirements/test.txt
 youtube-dl==2021.12.17
-    # via -r requirements/test.txt
+    # via -r /home/misha/work/cc2olx/requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -71,8 +71,11 @@ pytest==8.3.4
     # via
     #   -r /home/misha/work/cc2olx/requirements/test.txt
     #   pytest-cov
+    #   pytest-django
     #   pytest-mock
 pytest-cov==5.0.0
+    # via -r /home/misha/work/cc2olx/requirements/test.txt
+pytest-django==4.9.0
     # via -r /home/misha/work/cc2olx/requirements/test.txt
 pytest-mock==3.14.0
     # via -r /home/misha/work/cc2olx/requirements/test.txt

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,5 +6,6 @@
 coverage
 pytest
 pytest-cov
+pytest-django
 pytest-mock
 xmlformatter

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,33 +4,42 @@
 #
 #    make upgrade
 #
-certifi==2024.2.2
+asgiref==3.8.1
     # via
-    #   -r requirements/base.txt
-    #   requests
-charset-normalizer==3.3.2
+    #   -r /home/misha/work/cc2olx/requirements/base.txt
+    #   django
+backports-zoneinfo==0.2.1
     # via
-    #   -r requirements/base.txt
+    #   -r /home/misha/work/cc2olx/requirements/base.txt
+    #   django
+certifi==2024.12.14
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/base.txt
     #   requests
-coverage[toml]==7.4.4
+charset-normalizer==3.4.1
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/base.txt
+    #   requests
+coverage[toml]==7.6.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-exceptiongroup==1.2.0
+    # via -r /home/misha/work/cc2olx/requirements/base.txt
+exceptiongroup==1.2.2
     # via pytest
-idna==3.6
+idna==3.10
     # via
-    #   -r requirements/base.txt
+    #   -r /home/misha/work/cc2olx/requirements/base.txt
     #   requests
 iniconfig==2.0.0
     # via pytest
-lxml==5.1.0
-    # via -r requirements/base.txt
-packaging==24.0
+lxml==5.3.0
+    # via -r /home/misha/work/cc2olx/requirements/base.txt
+packaging==24.2
     # via pytest
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
-pytest==8.1.1
+pytest==8.3.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -39,17 +48,25 @@ pytest-cov==5.0.0
     # via -r requirements/test.in
 pytest-mock==3.14.0
     # via -r requirements/test.in
-requests==2.31.0
-    # via -r requirements/base.txt
-tomli==2.0.1
+requests==2.32.3
+    # via -r /home/misha/work/cc2olx/requirements/base.txt
+sqlparse==0.5.3
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/base.txt
+    #   django
+tomli==2.2.1
     # via
     #   coverage
     #   pytest
-urllib3==2.2.1
+typing-extensions==4.12.2
     # via
-    #   -r requirements/base.txt
+    #   -r /home/misha/work/cc2olx/requirements/base.txt
+    #   asgiref
+urllib3==2.2.3
+    # via
+    #   -r /home/misha/work/cc2olx/requirements/base.txt
     #   requests
-xmlformatter==0.2.6
+xmlformatter==0.2.8
     # via -r requirements/test.in
 youtube-dl==2021.12.17
-    # via -r requirements/base.txt
+    # via -r /home/misha/work/cc2olx/requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -43,8 +43,11 @@ pytest==8.3.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
+    #   pytest-django
     #   pytest-mock
 pytest-cov==5.0.0
+    # via -r requirements/test.in
+pytest-django==4.9.0
     # via -r requirements/test.in
 pytest-mock==3.14.0
     # via -r requirements/test.in

--- a/src/cc2olx/cli.py
+++ b/src/cc2olx/cli.py
@@ -2,6 +2,8 @@ import argparse
 
 from pathlib import Path
 
+from cc2olx.validators.cli import LinkSourceValidator
+
 RESULT_TYPE_FOLDER = "folder"
 RESULT_TYPE_ZIP = "zip"
 
@@ -73,6 +75,7 @@ def parse_args(args=None):
         "-s",
         "--relative_links_source",
         nargs="?",
+        type=LinkSourceValidator(),
         help="The relative links source in the format '<scheme>://<netloc>', e.g. 'https://example.com'",
     )
     return parser.parse_args(args)

--- a/src/cc2olx/cli.py
+++ b/src/cc2olx/cli.py
@@ -69,4 +69,10 @@ def parse_args(args=None):
             "should contain consumer_id, consumer_key and consumer_secret."
         ),
     )
+    parser.add_argument(
+        "-s",
+        "--relative_links_source",
+        nargs="?",
+        help="The relative links source in the format '<scheme>://<netloc>', e.g. 'https://example.com'",
+    )
     return parser.parse_args(args)

--- a/src/cc2olx/cli.py
+++ b/src/cc2olx/cli.py
@@ -2,7 +2,7 @@ import argparse
 
 from pathlib import Path
 
-from cc2olx.validators.cli import LinkSourceValidator
+from cc2olx.validators.cli import link_source_validator
 
 RESULT_TYPE_FOLDER = "folder"
 RESULT_TYPE_ZIP = "zip"
@@ -75,7 +75,7 @@ def parse_args(args=None):
         "-s",
         "--relative_links_source",
         nargs="?",
-        type=LinkSourceValidator(),
+        type=link_source_validator,
         help="The relative links source in the format '<scheme>://<netloc>', e.g. 'https://example.com'",
     )
     return parser.parse_args(args)

--- a/src/cc2olx/constants.py
+++ b/src/cc2olx/constants.py
@@ -1,1 +1,3 @@
 CDATA_PATTERN = r"<!\[CDATA\[(?P<content>.*?)\]\]>"
+OLX_STATIC_DIR = "static"
+OLX_STATIC_PATH_TEMPLATE = f"/{OLX_STATIC_DIR}/{{static_filename}}"

--- a/src/cc2olx/dataclasses.py
+++ b/src/cc2olx/dataclasses.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+from collections import ChainMap
+from typing import Dict
+
+
+@dataclass
+class OlxToOriginalStaticFilePaths:
+    """
+    Provide OLX static file to Common cartridge static file mappings.
+    """
+
+    # Static files from `web_resources` directory
+    web_resources: Dict[str, str] = field(default_factory=dict)
+    # Static files that are outside of `web_resources` directory, but still required
+    extra: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.all = ChainMap(self.extra, self.web_resources)

--- a/src/cc2olx/django_settings.py
+++ b/src/cc2olx/django_settings.py
@@ -1,0 +1,2 @@
+USE_I18N = False
+USE_TZ = False

--- a/src/cc2olx/main.py
+++ b/src/cc2olx/main.py
@@ -8,18 +8,25 @@ from pathlib import Path
 from cc2olx import filesystem
 from cc2olx import olx
 from cc2olx.cli import parse_args, RESULT_TYPE_FOLDER, RESULT_TYPE_ZIP
-from cc2olx.models import Cartridge, OLX_STATIC_DIR
+from cc2olx.constants import OLX_STATIC_DIR
+from cc2olx.models import Cartridge
 from cc2olx.settings import collect_settings
 
 
-def convert_one_file(input_file, workspace, link_file=None, passport_file=None):
+def convert_one_file(
+    input_file,
+    workspace,
+    link_file=None,
+    passport_file=None,
+    relative_links_source=None,
+):
     filesystem.create_directory(workspace)
 
     cartridge = Cartridge(input_file, workspace)
     cartridge.load_manifest_extracted()
     cartridge.normalize()
 
-    olx_export = olx.OlxExport(cartridge, link_file, passport_file)
+    olx_export = olx.OlxExport(cartridge, link_file, passport_file, relative_links_source)
     olx_filename = cartridge.directory.parent / (cartridge.directory.name + "-course.xml")
     policy_filename = cartridge.directory.parent / "policy.json"
 
@@ -53,6 +60,7 @@ def main():
     workspace = settings["workspace"]
     link_file = settings["link_file"]
     passport_file = settings["passport_file"]
+    relative_links_source = settings["relative_links_source"]
 
     # setup logger
     logging_config = settings["logging_config"]
@@ -64,7 +72,14 @@ def main():
 
         for input_file in settings["input_files"]:
             try:
-                convert_one_file(input_file, temp_workspace, link_file, passport_file)
+                convert_one_file(
+                    input_file,
+                    temp_workspace,
+                    link_file,
+                    passport_file,
+                    relative_links_source,
+                )
+
             except Exception:
                 logger.exception("Error while converting %s file", input_file)
 

--- a/src/cc2olx/main.py
+++ b/src/cc2olx/main.py
@@ -1,9 +1,11 @@
 import logging
+import os
 import shutil
 import sys
 import tempfile
-
 from pathlib import Path
+
+import django
 
 from cc2olx import filesystem
 from cc2olx import olx
@@ -54,6 +56,8 @@ def convert_one_file(
 
 
 def main():
+    initialize_django()
+
     parsed_args = parse_args()
     settings = collect_settings(parsed_args)
 
@@ -93,6 +97,14 @@ def main():
     logger.info("Conversion completed")
 
     return 0
+
+
+def initialize_django():
+    """
+    Initialize the Django package.
+    """
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cc2olx.django_settings")
+    django.setup()
 
 
 if __name__ == "__main__":

--- a/src/cc2olx/main.py
+++ b/src/cc2olx/main.py
@@ -46,8 +46,8 @@ def convert_one_file(
 
     # Add static files that are outside of web_resources directory
     file_list += [
-        (str(cartridge.directory / filepath), "/static/{}".format(filepath))
-        for filepath in cartridge.extra_static_files
+        (str(cartridge.directory / original_filepath), olx_static_path)
+        for olx_static_path, original_filepath in cartridge.olx_to_original_static_file_paths.extra.items()
     ]
 
     filesystem.add_in_tar_gz(str(tgz_filename), file_list)

--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 import zipfile
 
 from cc2olx import filesystem
+from cc2olx.constants import OLX_STATIC_PATH_TEMPLATE
 from cc2olx.external.canvas import ModuleMeta
 from cc2olx.qti import QtiParser
 from cc2olx.utils import clean_file_name
@@ -343,7 +344,7 @@ class Cartridge:
                 return "html", {"html": html}
             elif "web_resources" in str(res_filename) and imghdr.what(str(res_filename)):
                 static_filename = str(res_filename).split("web_resources/")[1]
-                olx_static_path = "/{}/{}".format(OLX_STATIC_DIR, static_filename)
+                olx_static_path = OLX_STATIC_PATH_TEMPLATE.format(static_filename=static_filename)
                 html = (
                     '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>'
                     '</head><body><p><img src="{}" alt="{}"></p></body></html>'.format(olx_static_path, static_filename)
@@ -353,7 +354,7 @@ class Cartridge:
                 # This webcontent is outside of ``web_resources`` directory
                 # So we need to manually copy it to OLX_STATIC_DIR
                 self.extra_static_files.append(res_relative_path)
-                olx_static_path = "/{}/{}".format(OLX_STATIC_DIR, res_relative_path)
+                olx_static_path = OLX_STATIC_PATH_TEMPLATE.format(static_filename=res_relative_path)
                 html = (
                     '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>'
                     '</head><body><p><a href="{}" alt="{}">{}<a></p></body></html>'.format(

--- a/src/cc2olx/models.py
+++ b/src/cc2olx/models.py
@@ -25,22 +25,6 @@ CANVAS_REPORT = "canvas_export.txt"
 DIFFUSE_SHALLOW_SECTIONS = False
 DIFFUSE_SHALLOW_SUBSECTIONS = True
 
-OLX_STATIC_DIR = "static"
-
-OLX_DIRECTORIES = [
-    "about",
-    "assets",
-    "chapter",
-    "course",
-    "html",
-    "info",
-    "policies",
-    "problem",
-    "sequential",
-    OLX_STATIC_DIR,
-    "vertical",
-]
-
 
 def is_leaf(container):
     return "identifierref" in container

--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -7,7 +7,6 @@ import xml.dom.minidom
 from lxml import html
 from cc2olx.iframe_link_parser import KalturaIframeLinkParser
 
-from cc2olx.constants import OLX_STATIC_PATH_TEMPLATE
 from cc2olx.qti import QtiExport
 from cc2olx.utils import clean_from_cdata, element_builder, passport_file_parser
 
@@ -252,7 +251,7 @@ class OlxExport:
             html = html.replace(item, external_tool_url)
             return html
 
-        def process_extra_static_files(item, html):
+        def process_relative_external_links(item, html):
             """
             Turn static file URLs outside OLX_STATIC_DIR into absolute URLs.
 
@@ -262,12 +261,8 @@ class OlxExport:
             course. The function adds the origin source to URLs to make them
             absolute ones.
             """
-            if self.relative_links_source is None:
+            if self.relative_links_source is None or item in self.cartridge.olx_to_original_static_file_paths.all:
                 return html
-
-            for static_file in self.cartridge.extra_static_files:
-                if item == OLX_STATIC_PATH_TEMPLATE.format(static_filename=static_file):
-                    return html
 
             url = urllib.parse.urljoin(self.relative_links_source, item)
             html = html.replace(item, url)
@@ -283,7 +278,7 @@ class OlxExport:
             elif "CANVAS_OBJECT_REFERENCE" in item:
                 html = process_canvas_reference(item, html)
             else:
-                html = process_extra_static_files(item, html)
+                html = process_relative_external_links(item, html)
 
         return html
 

--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -253,6 +253,15 @@ class OlxExport:
             return html
 
         def process_extra_static_files(item, html):
+            """
+            Turn static file URLs outside OLX_STATIC_DIR into absolute URLs.
+
+            Allow to avoid a situation when the original course page links have
+            relative URLs, such URLs weren't included into the exported Common
+            Cartridge course file that causes broken URLs in the imported OeX
+            course. The function adds the origin source to URLs to make them
+            absolute ones.
+            """
             if self.relative_links_source is None:
                 return html
 

--- a/src/cc2olx/settings.py
+++ b/src/cc2olx/settings.py
@@ -47,5 +47,6 @@ def collect_settings(parsed_args):
         "workspace": Path.cwd() / parsed_args.output,
         "link_file": parsed_args.link_file,
         "passport_file": parsed_args.passport_file,
+        "relative_links_source": parsed_args.relative_links_source,
     }
     return settings

--- a/src/cc2olx/utils.py
+++ b/src/cc2olx/utils.py
@@ -1,7 +1,6 @@
 """ Utility functions for cc2olx"""
 
 import csv
-import ipaddress
 import logging
 import re
 import string
@@ -124,14 +123,3 @@ def clean_from_cdata(xml_string: str) -> str:
         str: cleaned XML string.
     """
     return re.sub(CDATA_PATTERN, r"\g<content>", xml_string, flags=re.DOTALL)
-
-
-def is_valid_ipv6_address(value: str) -> bool:
-    """
-    Return whether the value is a valid IPv6 address.
-    """
-    try:
-        ipaddress.IPv6Address(value)
-    except ValueError:
-        return False
-    return True

--- a/src/cc2olx/utils.py
+++ b/src/cc2olx/utils.py
@@ -1,9 +1,10 @@
 """ Utility functions for cc2olx"""
 
-import logging
-import string
 import csv
+import ipaddress
+import logging
 import re
+import string
 
 from cc2olx.constants import CDATA_PATTERN
 
@@ -123,3 +124,14 @@ def clean_from_cdata(xml_string: str) -> str:
         str: cleaned XML string.
     """
     return re.sub(CDATA_PATTERN, r"\g<content>", xml_string, flags=re.DOTALL)
+
+
+def is_valid_ipv6_address(value: str) -> bool:
+    """
+    Return whether the value is a valid IPv6 address.
+    """
+    try:
+        ipaddress.IPv6Address(value)
+    except ValueError:
+        return False
+    return True

--- a/src/cc2olx/validators/cli.py
+++ b/src/cc2olx/validators/cli.py
@@ -19,9 +19,7 @@ class LinkSourceValidator:
     IPV6_REGEX = r"\[[0-9a-f:.]+\]"  # (simple regex, validated later)
 
     # Host patterns
-    HOSTNAME_REGEX = (
-        rf"[a-z{UL}0-9](?:[a-z{UL}0-9-]{{0,61}}[a-z{UL}0-9])?"
-    )
+    HOSTNAME_REGEX = rf"[a-z{UL}0-9](?:[a-z{UL}0-9-]{{0,61}}[a-z{UL}0-9])?"
     # Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
     DOMAIN_REGEX = rf"(?:\.(?!-)[a-z{UL}0-9-]{{1,63}}(?<!-))*"
     TLD_REGEX = (

--- a/src/cc2olx/validators/cli.py
+++ b/src/cc2olx/validators/cli.py
@@ -1,0 +1,64 @@
+import argparse
+import re
+
+from cc2olx.utils import is_valid_ipv6_address
+
+
+class LinkSourceValidator:
+    """
+    Validate a link source.
+    """
+
+    UL = "\u00a1-\uffff"  # Unicode letters range (must not be a raw string).
+
+    # IP patterns
+    IPV4_REGEX = (
+        r"(?:0|25[0-5]|2[0-4][0-9]|1[0-9]?[0-9]?|[1-9][0-9]?)"
+        r"(?:\.(?:0|25[0-5]|2[0-4][0-9]|1[0-9]?[0-9]?|[1-9][0-9]?)){3}"
+    )
+    IPV6_REGEX = r"\[[0-9a-f:.]+\]"  # (simple regex, validated later)
+
+    # Host patterns
+    HOSTNAME_REGEX = (
+        rf"[a-z{UL}0-9](?:[a-z{UL}0-9-]{{0,61}}[a-z{UL}0-9])?"
+    )
+    # Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
+    DOMAIN_REGEX = rf"(?:\.(?!-)[a-z{UL}0-9-]{{1,63}}(?<!-))*"
+    TLD_REGEX = (
+        r"\."  # dot
+        r"(?!-)"  # can't start with a dash
+        rf"(?:[a-z{UL}-]{{2,63}}"  # domain label
+        r"|xn--[a-z0-9]{1,59})"  # or punycode label
+        r"(?<!-)"  # can't end with a dash
+        r"\.?"  # may have a trailing dot
+    )
+    HOST_REGEX = "(" + HOSTNAME_REGEX + DOMAIN_REGEX + TLD_REGEX + "|localhost)"
+
+    LINK_SOURCE_REGEX = (
+        r"^https?://"  # scheme is validated separately
+        r"(?:[^\s:@/]+(?::[^\s:@/]*)?@)?"  # user:pass authentication
+        rf"(?P<netloc>{IPV4_REGEX}|{IPV6_REGEX}|{HOST_REGEX})"
+        r"(?::[0-9]{1,5})?"  # port
+        r"/?"  # trailing slash
+        r"\Z"
+    )
+
+    message = "Enter a valid URL."
+
+    def __call__(self, value: str) -> str:
+        if not (link_source_match := re.match(self.LINK_SOURCE_REGEX, value, re.IGNORECASE)):
+            raise argparse.ArgumentTypeError(self.message)
+
+        self._validate_ipv6_address(link_source_match.group("netloc"))
+
+        return value
+
+    def _validate_ipv6_address(self, netloc: str) -> None:
+        """
+        Check netloc correctness if it's an IPv6 address.
+        """
+        potential_ipv6_regex = r"^\[(.+)\](?::[0-9]{1,5})?$"
+        if netloc_match := re.search(potential_ipv6_regex, netloc):
+            potential_ip = netloc_match[1]
+            if is_valid_ipv6_address(potential_ip):
+                raise argparse.ArgumentTypeError(self.message)

--- a/src/cc2olx/validators/cli.py
+++ b/src/cc2olx/validators/cli.py
@@ -1,62 +1,40 @@
 import argparse
 import re
+from typing import Callable
 
-from cc2olx.utils import is_valid_ipv6_address
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
 
 
-class LinkSourceValidator:
+def convert_to_argparse_validator(django_validator: Callable) -> Callable:
     """
-    Validate a link source.
+    Convert a Django validator to an argparse validator.
+
+    If a Django ValidationError is raised during the validator call, it is
+    intercepted and an ArgumentTypeError is raised with the same message.
     """
 
-    UL = "\u00a1-\uffff"  # Unicode letters range (must not be a raw string).
-
-    # IP patterns
-    IPV4_REGEX = (
-        r"(?:0|25[0-5]|2[0-4][0-9]|1[0-9]?[0-9]?|[1-9][0-9]?)"
-        r"(?:\.(?:0|25[0-5]|2[0-4][0-9]|1[0-9]?[0-9]?|[1-9][0-9]?)){3}"
-    )
-    IPV6_REGEX = r"\[[0-9a-f:.]+\]"  # (simple regex, validated later)
-
-    # Host patterns
-    HOSTNAME_REGEX = rf"[a-z{UL}0-9](?:[a-z{UL}0-9-]{{0,61}}[a-z{UL}0-9])?"
-    # Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
-    DOMAIN_REGEX = rf"(?:\.(?!-)[a-z{UL}0-9-]{{1,63}}(?<!-))*"
-    TLD_REGEX = (
-        r"\."  # dot
-        r"(?!-)"  # can't start with a dash
-        rf"(?:[a-z{UL}-]{{2,63}}"  # domain label
-        r"|xn--[a-z0-9]{1,59})"  # or punycode label
-        r"(?<!-)"  # can't end with a dash
-        r"\.?"  # may have a trailing dot
-    )
-    HOST_REGEX = "(" + HOSTNAME_REGEX + DOMAIN_REGEX + TLD_REGEX + "|localhost)"
-
-    LINK_SOURCE_REGEX = (
-        r"^https?://"  # scheme is validated separately
-        r"(?:[^\s:@/]+(?::[^\s:@/]*)?@)?"  # user:pass authentication
-        rf"(?P<netloc>{IPV4_REGEX}|{IPV6_REGEX}|{HOST_REGEX})"
-        r"(?::[0-9]{1,5})?"  # port
-        r"/?"  # trailing slash
-        r"\Z"
-    )
-
-    message = "Enter a valid URL."
-
-    def __call__(self, value: str) -> str:
-        if not (link_source_match := re.fullmatch(self.LINK_SOURCE_REGEX, value, re.IGNORECASE)):
-            raise argparse.ArgumentTypeError(self.message)
-
-        self._validate_ipv6_address(link_source_match.group("netloc"))
-
+    def argparse_validator(value):
+        try:
+            django_validator(value)
+        except ValidationError as exc:
+            raise argparse.ArgumentTypeError(exc.message) from exc
         return value
 
-    def _validate_ipv6_address(self, netloc: str) -> None:
-        """
-        Check netloc correctness if it's an IPv6 address.
-        """
-        potential_ipv6_regex = r"^\[(.+)\](?::[0-9]{1,5})?$"
-        if netloc_match := re.search(potential_ipv6_regex, netloc):
-            potential_ip = netloc_match[1]
-            if not is_valid_ipv6_address(potential_ip):
-                raise argparse.ArgumentTypeError(self.message)
+    return argparse_validator
+
+
+link_source_validator = convert_to_argparse_validator(
+    URLValidator(
+        schemes=["http", "https"],
+        regex=(
+            r"^(?:[a-z0-9.+-]*)://"  # scheme is validated separately
+            r"(?:[^\s:@/]+(?::[^\s:@/]*)?@)?"  # user:pass authentication
+            r"(?:" + URLValidator.ipv4_re + "|" + URLValidator.ipv6_re + "|" + URLValidator.host_re + ")"
+            r"(?::[0-9]{1,5})?"  # port
+            r"/?"  # trailing slash
+            r"\Z"
+        ),
+        flags=re.IGNORECASE,
+    )
+)

--- a/src/cc2olx/validators/cli.py
+++ b/src/cc2olx/validators/cli.py
@@ -46,7 +46,7 @@ class LinkSourceValidator:
     message = "Enter a valid URL."
 
     def __call__(self, value: str) -> str:
-        if not (link_source_match := re.match(self.LINK_SOURCE_REGEX, value, re.IGNORECASE)):
+        if not (link_source_match := re.fullmatch(self.LINK_SOURCE_REGEX, value, re.IGNORECASE)):
             raise argparse.ArgumentTypeError(self.message)
 
         self._validate_ipv6_address(link_source_match.group("netloc"))
@@ -60,5 +60,5 @@ class LinkSourceValidator:
         potential_ipv6_regex = r"^\[(.+)\](?::[0-9]{1,5})?$"
         if netloc_match := re.search(potential_ipv6_regex, netloc):
             potential_ip = netloc_match[1]
-            if is_valid_ipv6_address(potential_ip):
+            if not is_valid_ipv6_address(potential_ip):
                 raise argparse.ArgumentTypeError(self.message)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,7 @@ def test_parse_args_with_incorrect_relative_links_source(imscc_file: Path) -> No
     """
     Test arguments parser detects incorrect relative links sources.
     """
-    relative_links_source = "ws://example.com",
+    relative_links_source = "ws://example.com"
 
     with pytest.raises(SystemExit):
         parse_args(["-i", str(imscc_file), "-s", relative_links_source])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,13 @@ def test_parse_args(imscc_file):
     )
 
     assert parsed_args == Namespace(
-        inputs=[imscc_file], loglevel="INFO", result="folder", link_file=None, passport_file=None, output="output"
+        inputs=[imscc_file],
+        loglevel="INFO",
+        result="folder",
+        link_file=None,
+        passport_file=None,
+        output="output",
+        relative_links_source=None,
     )
 
 
@@ -34,6 +40,7 @@ def test_parse_args_csv_file(imscc_file, link_map_csv):
         link_file=link_map_csv,
         passport_file=None,
         output="output",
+        relative_links_source=None,
     )
 
 
@@ -49,4 +56,5 @@ def test_parse_args_passport_file(imscc_file, passports_csv):
         link_file=None,
         passport_file=passports_csv,
         output="output",
+        relative_links_source=None,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,7 @@
 from argparse import Namespace
+from pathlib import Path
+
+import pytest
 
 from cc2olx.cli import parse_args
 
@@ -58,3 +61,32 @@ def test_parse_args_passport_file(imscc_file, passports_csv):
         output="output",
         relative_links_source=None,
     )
+
+
+def test_parse_args_with_correct_relative_links_source(imscc_file: Path) -> None:
+    """
+    Positive input test for relative links source argument.
+    """
+    relative_links_source = "https://example.com"
+
+    parsed_args = parse_args(["-i", str(imscc_file), "-s", relative_links_source])
+
+    assert parsed_args == Namespace(
+        inputs=[imscc_file],
+        loglevel="INFO",
+        result="folder",
+        link_file=None,
+        passport_file=None,
+        output="output",
+        relative_links_source=relative_links_source,
+    )
+
+
+def test_parse_args_with_incorrect_relative_links_source(imscc_file: Path) -> None:
+    """
+    Test arguments parser detects incorrect relative links sources.
+    """
+    relative_links_source = "ws://example.com",
+
+    with pytest.raises(SystemExit):
+        parse_args(["-i", str(imscc_file), "-s", relative_links_source])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,4 +19,5 @@ def test_collect_settings(imscc_file):
             "level": parsed_args.loglevel,
             "format": "{%(filename)s:%(lineno)d} - %(message)s",
         },
+        "relative_links_source": None,
     }

--- a/tests/test_validators/test_cli.py
+++ b/tests/test_validators/test_cli.py
@@ -1,0 +1,49 @@
+import argparse
+
+import pytest
+
+from cc2olx.validators.cli import LinkSourceValidator
+
+
+class TestLinkSourceValidator:
+    """
+    Test link source validator.
+    """
+
+    @pytest.mark.parametrize(
+        "links_source",
+        (
+            "http://example.com",
+            "http://example.com/",
+            "https://example.com",
+            "http://192.168.0.1",
+            "http://192.168.0.1:8000/",
+            "https://[2001:0db8:85a3::8a2e:0370:7334]/",
+        )
+    )
+    def test_original_value_is_returned_if_it_is_valid(self, links_source: str) -> None:
+        """
+        Test whether the validator returns original value it is valid.
+        """
+        assert LinkSourceValidator()(links_source) == links_source
+
+    @pytest.mark.parametrize(
+        "links_source",
+        (
+            "ftp://example.com",
+            "ws://example.com",
+            "just_string",
+            "http://192.168.0.1.9",
+            "http://192.168.0.1:-56",
+            "http://192.999.0.1",
+            "https://m192.168.0.1",
+            "https://2001:0db8:85a3::8a2e:0370:7334/",
+            "https://[2001:db8:85a3::8a2e:0370:7334::]/",
+        )
+    )
+    def test_wrong_values_are_detected(self, links_source) -> None:
+        """
+        Test whether the validator raises an error if the value is invalid.
+        """
+        with pytest.raises(argparse.ArgumentTypeError, match="Enter a valid URL."):
+            LinkSourceValidator()(links_source)

--- a/tests/test_validators/test_cli.py
+++ b/tests/test_validators/test_cli.py
@@ -19,7 +19,7 @@ class TestLinkSourceValidator:
             "http://192.168.0.1",
             "http://192.168.0.1:8000/",
             "https://[2001:0db8:85a3::8a2e:0370:7334]/",
-        )
+        ),
     )
     def test_original_value_is_returned_if_it_is_valid(self, links_source: str) -> None:
         """
@@ -39,7 +39,7 @@ class TestLinkSourceValidator:
             "https://m192.168.0.1",
             "https://2001:0db8:85a3::8a2e:0370:7334/",
             "https://[2001:db8:85a3::8a2e:0370:7334::]/",
-        )
+        ),
     )
     def test_wrong_values_are_detected(self, links_source) -> None:
         """


### PR DESCRIPTION
## Description
It is possible that the `.imscc` course dump contains files with relative links to resources for some reason not included into it (e.g. some static files of LMS that are not processed by its exporting tool). It can become a reason of broken images, not loaded styles etc.To handle such situations, it is allowed to specify the relative links source during converting.

## Usage instructions
Specify relative links source using `-s` flag:
```bash
cc2olx -i <IMSCC_FILE> -s <RELATIVE_LINKS_SOURCE>
```

## Supporting information
FC-0063

## Deadline
"None"