### PR TITLE
fix: [FC-0063] Multiple input files processing is fixed

### DIFF
--- a/src/cc2olx/cli.py
+++ b/src/cc2olx/cli.py
@@ -11,16 +11,16 @@ RESULT_TYPE_ZIP = "zip"
 def parse_args(args=None):
     parser = argparse.ArgumentParser(
         description=(
-            "This script converts imscc files into folders with " "all the content; in the defined folder structure."
+            "This script converts imscc files into folders with all the content; in the defined folder structure."
         )
     )
     parser.add_argument(
         "-i",
         "--inputs",
-        nargs="*",
+        action="append",
         type=lambda p: Path(p).absolute(),
         required=True,
-        help=("Please provide the paths to the imscc files or directories " "that contain them."),
+        help="Please provide the paths to the imscc files or directories that contain them.",
     )
     parser.add_argument(
         "-l",


### PR DESCRIPTION
## Description
There was an error that after specifying several input files, only the last one was processed. It's fixed and all input files are processed now.

## Steps to reproduce
1. Run the script with several `.imscc` input files:

   ```bash
   cc2olx -i file1.imscc -i file2.imscc
   ```
2. Check `output` directory. It contain only `file2.imscc` processing outputs.

## Supporting information
FC-0063

## Deadline
"None"