### PR TITLE
feat: Google document blocks processing is implemented

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ Converted:
 - QTI assessments
 - Assignments
 - PDF files
+- Google document URLs
 
 Not converted:
 
@@ -75,6 +76,7 @@ used. The argument values correspond to the xBlock names to specify in
 Supported Custom xBlocks:
 
 - `pdf <https://github.com/raccoongang/xblock-pdf>`_
+- `google-document <https://github.com/openedx/xblock-google-drive>`_
 
 Argument usage example::
 

--- a/src/cc2olx/content_processors/__init__.py
+++ b/src/cc2olx/content_processors/__init__.py
@@ -1,6 +1,7 @@
 from cc2olx.content_processors.abc import AbstractContentProcessor
 from cc2olx.content_processors.assignment import AssignmentContentProcessor
 from cc2olx.content_processors.discussion import DiscussionContentProcessor
+from cc2olx.content_processors.google_document import GoogleDocumentContentProcessor
 from cc2olx.content_processors.html import HtmlContentProcessor
 from cc2olx.content_processors.lti import LtiContentProcessor
 from cc2olx.content_processors.pdf import PDFContentProcessor
@@ -11,6 +12,7 @@ __all__ = [
     "AbstractContentProcessor",
     "AssignmentContentProcessor",
     "DiscussionContentProcessor",
+    "GoogleDocumentContentProcessor",
     "HtmlContentProcessor",
     "LtiContentProcessor",
     "PDFContentProcessor",

--- a/src/cc2olx/content_processors/google_document.py
+++ b/src/cc2olx/content_processors/google_document.py
@@ -1,0 +1,95 @@
+import html
+import re
+import xml.dom.minidom
+from typing import Dict, List, Optional
+
+from lxml import etree
+
+from cc2olx.content_processors import AbstractContentProcessor
+from cc2olx.content_processors.utils import parse_web_link_content
+from cc2olx.enums import SupportedCustomBlockContentType
+from cc2olx.utils import element_builder
+
+
+class GoogleDocumentContentProcessor(AbstractContentProcessor):
+    """
+    Google document content parser.
+
+    For resources that represent a Google document (documents/spreadsheets/
+    presentations/forms etc.) except drawings, generate the Google Drive xBlock
+    (https://github.com/openedx/xblock-google-drive) OLX to display the
+    document on the course page directly.
+    """
+
+    SUPPORTED_GOOGLE_DOCUMENT_URL_PATTERN = r"^https?:\/\/docs\.google\.com\/(?!drawings\/)([^\/]+)\/d\/.*$"
+    # Standard iframe settings added by Google document xBlock by default.
+    DEFAULT_GOOGLE_DOCUMENT_IFRAME_ATTRIBUTES = {
+        "frameborder": "0",
+        "width": "960",
+        "height": "569",
+        "allowfullscreen": "true",
+        "mozallowfullscreen": "true",
+        "webkitallowfullscreen": "true",
+    }
+
+    def process(self, resource: dict, idref: str) -> Optional[List[xml.dom.minidom.Element]]:
+        if not self._context.is_content_type_with_custom_block_used(SupportedCustomBlockContentType.GOOGLE_DOCUMENT):
+            return None
+
+        if content := self._parse(resource):
+            return self._create_nodes(content)
+        return None
+
+    def _parse(self, resource: dict) -> Optional[dict]:
+        """
+        Parse the resource content.
+        """
+        if web_link_content := parse_web_link_content(resource, self._cartridge):
+            return self._transform_web_link_content_to_google_document(web_link_content)
+        return None
+
+    def _transform_web_link_content_to_google_document(
+        self,
+        web_link_content: Dict[str, str],
+    ) -> Optional[Dict[str, str]]:
+        """
+        Build Google document block data from Web Link resource data.
+        """
+        web_link_url = web_link_content["href"]
+        return (
+            {"url": web_link_url} if re.match(self.SUPPORTED_GOOGLE_DOCUMENT_URL_PATTERN, web_link_url, re.I) else None
+        )
+
+    def _create_nodes(self, content: dict) -> List[xml.dom.minidom.Element]:
+        """
+        Give out <google-document> OLX nodes.
+        """
+        doc = xml.dom.minidom.Document()
+        el = element_builder(doc)
+        google_document_node = el("google-document", [], self._generate_google_document_attributes(content))
+        return [google_document_node]
+
+    def _generate_google_document_attributes(self, content: Dict[str, str]) -> Dict[str, str]:
+        """
+        Generate Google document tag attributes.
+        """
+        google_document_iframe = self._create_google_document_iframe(content)
+        google_document_iframe_string = html.unescape(
+            etree.tostring(google_document_iframe, pretty_print=True, method="html").decode("utf-8")
+        )
+        return {"embed_code": google_document_iframe_string}
+
+    def _create_google_document_iframe(self, content: Dict[str, str]) -> etree.ElementBase:
+        """
+        Create HTML iframe tag pointing to Google document.
+        """
+        return etree.Element("iframe", self._generate_google_document_iframe_attributes(content))
+
+    def _generate_google_document_iframe_attributes(self, content: Dict[str, str]) -> Dict[str, str]:
+        """
+        Generate Google document HTML iframe tag attributes.
+        """
+        return {
+            **self.DEFAULT_GOOGLE_DOCUMENT_IFRAME_ATTRIBUTES,
+            "src": content["url"],
+        }

--- a/src/cc2olx/enums.py
+++ b/src/cc2olx/enums.py
@@ -26,6 +26,7 @@ class SupportedCustomBlockContentType(StrEnum):
     """
 
     PDF = "pdf"
+    GOOGLE_DOCUMENT = "google-document"
 
     @property
     def file_extensions(self) -> Set[str]:
@@ -34,4 +35,5 @@ class SupportedCustomBlockContentType(StrEnum):
         """
         return {
             self.PDF: {".pdf"},
+            SupportedCustomBlockContentType.GOOGLE_DOCUMENT: set(),
         }[self]

--- a/src/cc2olx/settings.py
+++ b/src/cc2olx/settings.py
@@ -7,6 +7,7 @@ LOG_FORMAT = "{%(filename)s:%(lineno)d} - %(message)s"
 
 CUSTOM_BLOCKS_CONTENT_PROCESSORS = [
     "cc2olx.content_processors.PDFContentProcessor",
+    "cc2olx.content_processors.GoogleDocumentContentProcessor",
 ]
 
 # It is used to specify content processors applied to Common Cartridge

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def content_types_with_custom_blocks() -> List[str]:
     """
     Provide content types with custom blocks.
     """
-    return ["pdf"]
+    return ["pdf", "google-document"]
 
 
 @pytest.fixture

--- a/tests/fixtures_data/imscc_files/main/imsmanifest.xml
+++ b/tests/fixtures_data/imscc_files/main/imsmanifest.xml
@@ -84,6 +84,18 @@
                     <item identifier="web_link_to_pdf" identifierref="resource_web_link_to_pdf">
                         <title>Web Link to PDF file</title>
                     </item>
+                    <item identifier="web_link_to_google_document" identifierref="resource_web_link_to_google_document">
+                        <title>Web Link to Google document file</title>
+                    </item>
+                    <item identifier="web_link_to_google_presentation" identifierref="resource_web_link_to_google_presentation">
+                        <title>Web Link to Google presentation file</title>
+                    </item>
+                    <item identifier="web_link_to_google_drawings" identifierref="resource_web_link_to_google_drawings">
+                        <title>Web Link to Google drawings file</title>
+                    </item>
+                    <item identifier="web_link_to_google_docs_home_page" identifierref="resource_web_link_to_google_docs_home_page">
+                        <title>Web Link to Google docs home page</title>
+                    </item>
                 </item>
                 <item identifier="sequence2">
                     <title>Sequence2</title>
@@ -187,6 +199,18 @@
         </resource>
         <resource identifier="resource_web_link_to_pdf" type="imswl_xmlv1p3">
             <file href="weblinks/web_link_to_pdf.xml"/>
+        </resource>
+        <resource identifier="resource_web_link_to_google_document" type="imswl_xmlv1p3">
+            <file href="weblinks/web_link_to_google_document.xml"/>
+        </resource>
+        <resource identifier="resource_web_link_to_google_presentation" type="imswl_xmlv1p3">
+            <file href="weblinks/web_link_to_google_presentation.xml"/>
+        </resource>
+        <resource identifier="resource_web_link_to_google_drawings" type="imswl_xmlv1p3">
+            <file href="weblinks/web_link_to_google_drawings.xml"/>
+        </resource>
+        <resource identifier="resource_web_link_to_google_docs_home_page" type="imswl_xmlv1p3">
+            <file href="weblinks/web_link_to_google_docs_home_page.xml"/>
         </resource>
         <resource identifier="resource_9_youtube_web_link" type="imswl_xmlv1p3">
             <file href="weblinks/youtube_web_link.xml"/>

--- a/tests/fixtures_data/imscc_files/main/weblinks/web_link_to_google_docs_home_page.xml
+++ b/tests/fixtures_data/imscc_files/main/weblinks/web_link_to_google_docs_home_page.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webLink xmlns="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_imswl_v1p3.xsd">
+    <title>Google docs home</title>
+    <url href="https://docs.google.com/document/u/0/"/>
+</webLink>

--- a/tests/fixtures_data/imscc_files/main/weblinks/web_link_to_google_document.xml
+++ b/tests/fixtures_data/imscc_files/main/weblinks/web_link_to_google_document.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webLink xmlns="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_imswl_v1p3.xsd">
+    <title>Newsletter</title>
+    <url href="https://docs.google.com/document/d/e/2PACM-2vSgI8MVby87GGR7kmVPlzbcDFp8I1hjvhzM3lEPebKnb14cR8mvZf8JDpWs9KvVdwAXgpMUjAL9Nqbj/pub?embedded=true"/>
+</webLink>

--- a/tests/fixtures_data/imscc_files/main/weblinks/web_link_to_google_drawings.xml
+++ b/tests/fixtures_data/imscc_files/main/weblinks/web_link_to_google_drawings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webLink xmlns="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_imswl_v1p3.xsd">
+    <title>Picture example</title>
+    <url href="https://docs.google.com/drawings/d/e/2PACX-1vTDskPsAcSoDz6D0swCEuf9n7R67X0zuaDLIrDorbon9JhmIjtW_1bm0PbjcU7M2xzUOXA3asuSih2t/pub?w=960&amp;h=720"/>
+</webLink>

--- a/tests/fixtures_data/imscc_files/main/weblinks/web_link_to_google_presentation.xml
+++ b/tests/fixtures_data/imscc_files/main/weblinks/web_link_to_google_presentation.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webLink xmlns="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsccv1p3/imswl_v1p3 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_imswl_v1p3.xsd">
+    <title>Google document tool</title>
+    <url href="http://docs.google.com/presentation/d/1x2ZuzqHsMoh1epK8VsGAlanSo7r9z55ualwQlj-ofBQ/embed?start=true&amp;loop=true&amp;delayms=10000"/>
+</webLink>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -254,6 +254,18 @@
 			<vertical display_name="Web Link to PDF file" url_name="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
 				<pdf display_name="Web Link to PDF file" url="https://pdf.storage.com/python/proposals/PEP_312.pdf" url_name="resource_web_link_to_pdf"/>
 			</vertical>
+			<vertical display_name="Web Link to Google document file" url_name="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+				<google-document display_name="Web Link to Google document file" embed_code="&lt;iframe frameborder=&quot;0&quot; width=&quot;960&quot; height=&quot;569&quot; allowfullscreen=&quot;true&quot; mozallowfullscreen=&quot;true&quot; webkitallowfullscreen=&quot;true&quot; src=&quot;https://docs.google.com/document/d/e/2PACM-2vSgI8MVby87GGR7kmVPlzbcDFp8I1hjvhzM3lEPebKnb14cR8mvZf8JDpWs9KvVdwAXgpMUjAL9Nqbj/pub?embedded=true&quot;&gt;&lt;/iframe&gt; " url_name="resource_web_link_to_google_document"/>
+			</vertical>
+			<vertical display_name="Web Link to Google presentation file" url_name="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+				<google-document display_name="Web Link to Google presentation file" embed_code="&lt;iframe frameborder=&quot;0&quot; width=&quot;960&quot; height=&quot;569&quot; allowfullscreen=&quot;true&quot; mozallowfullscreen=&quot;true&quot; webkitallowfullscreen=&quot;true&quot; src=&quot;http://docs.google.com/presentation/d/1x2ZuzqHsMoh1epK8VsGAlanSo7r9z55ualwQlj-ofBQ/embed?start=true&amp;loop=true&amp;delayms=10000&quot;&gt;&lt;/iframe&gt; " url_name="resource_web_link_to_google_presentation"/>
+			</vertical>
+			<vertical display_name="Web Link to Google drawings file" url_name="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+				<html display_name="Web Link to Google drawings file" url_name="resource_web_link_to_google_drawings"><![CDATA[<a href="https://docs.google.com/drawings/d/e/2PACX-1vTDskPsAcSoDz6D0swCEuf9n7R67X0zuaDLIrDorbon9JhmIjtW_1bm0PbjcU7M2xzUOXA3asuSih2t/pub?w=960&h=720">Picture example</a>]]></html>
+			</vertical>
+			<vertical display_name="Web Link to Google docs home page" url_name="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+				<html display_name="Web Link to Google docs home page" url_name="resource_web_link_to_google_docs_home_page"><![CDATA[<a href="https://docs.google.com/document/u/0/">Google docs home</a>]]></html>
+			</vertical>
 		</sequential>
 	</chapter>
 	<chapter display_name="Sequence2" url_name="sequence2">

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from argparse import Namespace
 from pathlib import Path
+from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -98,11 +99,13 @@ def test_parse_args_with_incorrect_relative_links_source(imscc_file: Path) -> No
         parse_args(["-i", str(imscc_file), "-s", relative_links_source])
 
 
-def test_parse_args_with_correct_content_types_with_custom_blocks(imscc_file: Path) -> None:
+def test_parse_args_with_correct_content_types_with_custom_blocks(
+    imscc_file: Path,
+    content_types_with_custom_blocks: List[str],
+) -> None:
     """
     Positive input test for content types with custom blocks argument.
     """
-    content_types_with_custom_blocks = ["pdf"]
     content_types_with_custom_blocks_args = build_multi_value_args("-c", content_types_with_custom_blocks)
 
     parsed_args = parse_args(["-i", str(imscc_file), *content_types_with_custom_blocks_args])

--- a/tests/test_content_processors/test_google_document.py
+++ b/tests/test_content_processors/test_google_document.py
@@ -1,0 +1,93 @@
+import pytest
+
+from cc2olx.content_processors.dataclasses import ContentProcessorContext
+from cc2olx.content_processors.google_document import GoogleDocumentContentProcessor
+
+
+class TestGoogleDocumentContentProcessor:
+    def test_resource_is_not_processed_if_google_document_block_is_not_used(
+        self,
+        cartridge,
+        empty_content_processor_context,
+    ):
+        processor = GoogleDocumentContentProcessor(cartridge, empty_content_processor_context)
+        idref = "resource_google_doc_1"
+        resource = cartridge.define_resource(idref)
+
+        assert processor.process(resource, idref) is None
+
+    @pytest.mark.parametrize(
+        "not_weblink_webcontent_idref",
+        ["resource_6_wiki_content", "resource_5_image_file", "resource_pdf_1", "resource_3_vertical"],
+    )
+    def test_parse_returns_none_if_resource_is_not_weblink(
+        self,
+        cartridge,
+        not_weblink_webcontent_idref,
+    ):
+        context = ContentProcessorContext(
+            iframe_link_parser=None,
+            lti_consumer_ids=set(),
+            content_types_with_custom_blocks=["google-document"],
+        )
+        processor = GoogleDocumentContentProcessor(cartridge, context)
+        resource = cartridge.define_resource(not_weblink_webcontent_idref)
+
+        assert processor._parse(resource) is None
+
+    @pytest.mark.parametrize(
+        "web_link_url",
+        [
+            "https://docs.google.com/drawings/d/e/2PACX-1vTDskPsAcSoDz6D0swCEuf9n7R67X0zuaDLIrDorbon9/pub?w=960&h=720",
+            "https://docs.google.com/document/u/0/?tgif=d",
+            "https://docs.google.com/spreadsheets/u/1/",
+            "/2PACX-1vTDskPsAcSoDz6D0swCEuf9n7R67X0zuaDLIrDorbon9/pub?w=960&h=720",
+            "https://example.com",
+            "http://example.com",
+        ],
+    )
+    def test_transform_web_link_content_to_google_document_when_web_link_points_to_unsupported_url(
+        self,
+        cartridge,
+        web_link_url,
+    ):
+        context = ContentProcessorContext(
+            iframe_link_parser=None,
+            lti_consumer_ids=set(),
+            content_types_with_custom_blocks=["google-document"],
+        )
+        processor = GoogleDocumentContentProcessor(cartridge, context)
+        web_link_content = {"href": web_link_url}
+
+        assert processor._transform_web_link_content_to_google_document(web_link_content) is None
+
+    @pytest.mark.parametrize(
+        "web_link_url",
+        [
+            "https://docs.google.com/document/d/e/2pBGYHuDWfc8lEcAvwZ1ZdCGER59pH7CvyM1WDMWXFZM/edit",
+            "https://docs.google.com/document/d/e/2pBGYHuDWfc8lEcAvwZ1ZdCGER59pH7CvyM1WDMWXFZM/pub",
+            "https://docs.google.com/document/d/2pBGYHuDWfc8lEcAvwZ1ZdCGER59pH7CvyM1WDMWXFZM/pub",
+            "http://docs.google.com/document/d/2pBGYHuDWfc8lEcAvwZ1ZdCGER59pH7CvyM1WDMWXFZM/pub",
+            "https://docs.google.com/spreadsheets/d/2pBGYHuDWfc8lEcAvwZ1ZdCGER59pH7CvyM1WDMWXFZM/pub",
+            "https://docs.google.com/spreadsheets/d/2pBGYHuDWfc8lEcAvwZ1ZdCGER59pH7CvyM1WDMWXFZM",
+            "http://docs.google.com/presentation/d/2pBGYHuDWfc8lEcAvwZ1ZdCGER59pH7CvyM1WDM/embed?start=true&loop=true",
+            "https://docs.google.com/forms/d/e/2pBGYHuDWfc8lEcAvwZ1ZdCGER59pH7CvyM1WDMWXFZM/alreadyresponded",
+        ],
+    )
+    def test_transform_web_link_content_to_google_document_when_web_link_points_to_supported_url(
+        self,
+        cartridge,
+        web_link_url,
+    ):
+        context = ContentProcessorContext(
+            iframe_link_parser=None,
+            lti_consumer_ids=set(),
+            content_types_with_custom_blocks=["google-document"],
+        )
+        processor = GoogleDocumentContentProcessor(cartridge, context)
+        web_link_content = {"href": web_link_url}
+        expected_content = {"url": web_link_url}
+
+        actual_content = processor._transform_web_link_content_to_google_document(web_link_content)
+
+        assert actual_content == expected_content

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,7 +35,7 @@ def test_load_manifest_extracted(imscc_file, options, temp_workspace_path):
         "version": cartridge_version,
     }
 
-    assert len(cartridge.resources) == 24
+    assert len(cartridge.resources) == 28
     assert len(cartridge.resources[0]["children"]) == 6
     assert isinstance(cartridge.resources[0]["children"][0], ResourceFile)
 
@@ -242,6 +242,54 @@ def test_cartridge_normalize(imscc_file, options):
                                 "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                                 "identifierref": None,
                                 "title": "Web Link to PDF file",
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "web_link_to_google_document",
+                                        "identifierref": "resource_web_link_to_google_document",
+                                        "title": "Web Link to Google document file",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "Web Link to Google document file",
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "web_link_to_google_presentation",
+                                        "identifierref": "resource_web_link_to_google_presentation",
+                                        "title": "Web Link to Google presentation file",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "Web Link to Google presentation file",
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "web_link_to_google_drawings",
+                                        "identifierref": "resource_web_link_to_google_drawings",
+                                        "title": "Web Link to Google drawings file",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "Web Link to Google drawings file",
+                            },
+                            {
+                                "children": [
+                                    {
+                                        "identifier": "web_link_to_google_docs_home_page",
+                                        "identifierref": "resource_web_link_to_google_docs_home_page",
+                                        "title": "Web Link to Google docs home page",
+                                    }
+                                ],
+                                "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                "identifierref": None,
+                                "title": "Web Link to Google docs home page",
                             },
                         ],
                         "identifier": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",


### PR DESCRIPTION
## Description
Originally, weblinks pointing to Google documents, spreadsheets, presentations, forms are displayed as an HTML OeX xblock.  
It is allowed to render such document inside the unit without the need to follow the link. The [xblock-google-drive](https://github.com/openedx/xblock-google-drive) xblock is used for this purpose. To use this feature, it's needed to pass the block name with `--content_types_with_custom_blocks` (or `-c`) CLI argument:
```
cc2olx -i cc_archive.imscc -c "google-document"
```

## Supporting information
FC-0063

## Deadline
"None"